### PR TITLE
Update PKGBUILD

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -19,9 +19,13 @@ package() {
 
    msg2 "Copying files..."
    mkdir -p $pkgdir/usr/bin
+   # adding entry for GNOME3
+   mkdir -p $pkgdir/usr/share/applications
    mkdir -p $pkgdir/etc/skel/Desktop
    mkdir -p $pkgdir/usr/lib/mtinstall
    cp bin/mtinstall "$pkgdir/usr/bin/mtinstall"
+   # adding entry for GNOME3 to show in main menu installer
+   cp bin/installer.desktop "$pkgdir/usr/share/applications"
    cp bin/installer.desktop "$pkgdir/etc/skel/Desktop"
    cp -a locales "$pkgdir/usr/lib/mtinstall"
 }


### PR DESCRIPTION
I added that lines for gnome3. don't know how to make installer to check what version of is using so this will work as well. In other DE will not distrurb entry in /usr/share/applications/*.desktop as I know...
